### PR TITLE
작업 내용

### DIFF
--- a/ahzit/HELP.md
+++ b/ahzit/HELP.md
@@ -1,0 +1,26 @@
+# Getting Started
+
+### Reference Documentation
+For further reference, please consider the following sections:
+
+* [Official Apache Maven documentation](https://maven.apache.org/guides/index.html)
+* [Spring Boot Maven Plugin Reference Guide](https://docs.spring.io/spring-boot/docs/2.7.5/maven-plugin/reference/html/)
+* [Create an OCI image](https://docs.spring.io/spring-boot/docs/2.7.5/maven-plugin/reference/html/#build-image)
+* [Spring Boot DevTools](https://docs.spring.io/spring-boot/docs/2.7.5/reference/htmlsingle/#using.devtools)
+* [Java Mail Sender](https://docs.spring.io/spring-boot/docs/2.7.5/reference/htmlsingle/#io.email)
+* [Spring Boot Actuator](https://docs.spring.io/spring-boot/docs/2.7.5/reference/htmlsingle/#actuator)
+* [JDBC API](https://docs.spring.io/spring-boot/docs/2.7.5/reference/htmlsingle/#data.sql)
+* [MyBatis Framework](https://mybatis.org/spring-boot-starter/mybatis-spring-boot-autoconfigure/)
+* [Spring Web](https://docs.spring.io/spring-boot/docs/2.7.5/reference/htmlsingle/#web)
+
+### Guides
+The following guides illustrate how to use some features concretely:
+
+* [Building a RESTful Web Service with Spring Boot Actuator](https://spring.io/guides/gs/actuator-service/)
+* [Accessing Relational Data using JDBC with Spring](https://spring.io/guides/gs/relational-data-access/)
+* [Managing Transactions](https://spring.io/guides/gs/managing-transactions/)
+* [MyBatis Quick Start](https://github.com/mybatis/spring-boot-starter/wiki/Quick-Start)
+* [Building a RESTful Web Service](https://spring.io/guides/gs/rest-service/)
+* [Serving Web Content with Spring MVC](https://spring.io/guides/gs/serving-web-content/)
+* [Building REST services with Spring](https://spring.io/guides/tutorials/rest/)
+

--- a/ahzit/src/main/java/com/kh/ahzit/controller/FreeboardController.java
+++ b/ahzit/src/main/java/com/kh/ahzit/controller/FreeboardController.java
@@ -1,18 +1,29 @@
 package com.kh.ahzit.controller;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.kh.ahzit.entity.FreeboardDto;
 import com.kh.ahzit.repository.FreeboardDao;
+import com.kh.ahzit.vo.FreeboardListSeachVO;
 
-@Controller
+@Controller // 자유 게시판에 대한 Controller
 @RequestMapping("/freeboard")
 public class FreeboardController {
 
@@ -27,7 +38,7 @@ public class FreeboardController {
 		return "freeboard/write";
 	}
 	
-	// 게시글 등록 DB처리 Mapping
+	// 게시글 등록 DB 처리 Mapping
 	@PostMapping("/write")
 	public String writeFreeboard(HttpSession session, FreeboardDto freeboardDto, RedirectAttributes attr) {
 		// 시퀀스 번호 반환
@@ -35,9 +46,9 @@ public class FreeboardController {
 		// 반환한 번호를 입력받은 freeboardDto의 freeboardNo로 설정
 		freeboardDto.setFreeboardNo(freeboardNo);
 		// HttpSession에서 로그인 중인 회원 아이디 반환
-		String freeboardWriter = (String)session.getAttribute("loginId");
+		String userId = (String)session.getAttribute("loginId");
 		// 반환한 아이디를 입력받은 freeboardDto의 freeboardWriter로 설정
-		freeboardDto.setFreeboardWriter(freeboardWriter);
+		freeboardDto.setFreeboardWriter(userId);
 		// 게시글 등록 DB 처리
 		freeboardDao.insertFreeboard(freeboardDto);
 		// 해당 게시글의 상세 페이지로 강제 이동(redirect)
@@ -45,5 +56,67 @@ public class FreeboardController {
 		return "redirect:detail";
 	}
 	
-	// 게시글 조회 Mapping (회원)
+	// 게시글 목록 Mapping (회원)
+	@GetMapping("/list")
+	public String selectFreeboard(Model model, @ModelAttribute FreeboardListSeachVO freeboardListSeachVO) {
+		// 유형에 따른 게시글 조회 결과 반환
+		List<FreeboardDto> freeboardList = freeboardDao.searchFreeboard(freeboardListSeachVO);
+		// 조회 결과를 model에 추가
+		model.addAttribute("freeboardList", freeboardList);
+		// 게시글 목록 페이지(list.jsp)로 연결
+		return "freeboard/list";
+	}
+	
+	// 게시글 상세 Mapping (회원)
+	@GetMapping("/detail")
+	public String detailFreeboard(Model model, @RequestParam int freeboardNo) {
+		// 입력받은 자유게시글 번호로 단일 조회
+		FreeboardDto findDto = freeboardDao.detailFreeboard(freeboardNo);
+		// 조회 결과를 model에 추가
+		model.addAttribute("freeboardDto", findDto);
+		// 게시글 상세 페이지(detail.jsp)로 연결
+		return "freeboard/detail";
+	}
+	
+	// 게시글 수정 페이지 Mapping
+	@GetMapping("/edit")
+	public String editFreeboard(Model model, @RequestParam int freeboardNo) {
+		// 입력받은 자유게시글 번호로 단일 조회
+		FreeboardDto findDto = freeboardDao.detailFreeboard(freeboardNo);
+		// 조회 결과를 model에 추가
+		model.addAttribute("freeboardDto", findDto);
+		// 게시글 수정 페이지(edit.jsp)로 연결
+		return "freeboard/edit";
+	}
+	
+	// 게시글 수정 DB 처리 Mapping
+	@PostMapping("/edit")
+	public String editFreeboard(@ModelAttribute FreeboardDto freeboardDto, RedirectAttributes attr) throws Exception {
+		// 입력받은 freeboardDto로 게시글 수정 처리 후 결과 반환
+		boolean isEditted = freeboardDao.updateFreeboard(freeboardDto);
+		// 수정 성공 여부에 따라 서로 다른 처리
+		if(isEditted) { // 수정 성공시
+			// 수정한 게시글의 게시글 상세 Mapping으로 강제 이동
+			attr.addAttribute("freeboardNo", freeboardDto.getFreeboardNo());
+			return "redirect:detail";
+		}
+		else { // 수정 실패시
+			throw new Exception(); // 오류 발생
+		}
+	}
+	
+	// 게시글 비활성화 Mapping (회원일 경우 삭제 / 관리자일 경우 블라인드)
+	@GetMapping("/inactive")
+	public String inactiveFreeboard(@RequestParam int freeboardNo) throws Exception {
+		// 입력받은 자유게시글 번호로 비활성화 처리 후 결과 반환
+		boolean isInactive = freeboardDao.inactiveFreeboard(freeboardNo);
+		// 비활성화 성공 여부에 따라 서로 다른 처리
+		if(isInactive) { // 비활성화 성공시
+			// 게시글 목록 Mapping으로 강제 이동
+			return "redirect:list";
+		}
+		else { // 비활성화 실패시 
+			throw new Exception(); // 오류 발생
+		}
+	}
 }

--- a/ahzit/src/main/java/com/kh/ahzit/repository/FreeboardDao.java
+++ b/ahzit/src/main/java/com/kh/ahzit/repository/FreeboardDao.java
@@ -1,12 +1,36 @@
 package com.kh.ahzit.repository;
 
+import java.util.List;
+
 import com.kh.ahzit.entity.FreeboardDto;
+import com.kh.ahzit.vo.FreeboardListSeachVO;
 
 public interface FreeboardDao {
 
-	// 추상 메소드 - 등록할 게시글 번호 반환
+	// 추상 메소드 - 등록할 자유게시글 번호 반환
 	public int nextFreeboardNo();
 	
-	// 추상 메소드 - 자유게시판 게시글 등록
+	// 추상 메소드 - 자유게시글 등록
 	public void insertFreeboard(FreeboardDto freeboardDto);
+	
+	// 추상 메소드 - 자유게시글 조회
+	public List<FreeboardDto> searchFreeboard(FreeboardListSeachVO freeboardListSeachVO);
+	
+	// 추상 메소드 - 자유게시글 검색 조회
+	public List<FreeboardDto> selectSearch(FreeboardListSeachVO freeboardListSeachVO);
+	
+	// 추상 메소드 - 자유게시글 전체 조회
+	public List<FreeboardDto> selectAll(FreeboardListSeachVO freeboardListSeachVO);
+	
+	// 추상 메소드 - 자유게시글 상세 조회
+	public FreeboardDto detailFreeboard(int freeboardNo);
+	
+	// 추상 메소드 - 조회수 증가
+	public void updateFreeboardRead(int freeboardNo);
+	
+	// 추상 메소드 - 자유게시글 수정
+	public boolean updateFreeboard(FreeboardDto freeboardDto);
+	
+	// 추상 메소드 - 자유게시글 비활성화
+	public boolean inactiveFreeboard(int freeboardNo);
 }

--- a/ahzit/src/main/java/com/kh/ahzit/repository/FreeboardDaoImpl.java
+++ b/ahzit/src/main/java/com/kh/ahzit/repository/FreeboardDaoImpl.java
@@ -1,14 +1,21 @@
 package com.kh.ahzit.repository;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.ibatis.session.SqlSession;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import com.kh.ahzit.entity.FreeboardDto;
+import com.kh.ahzit.vo.FreeboardListSeachVO;
 
 @Repository
 public class FreeboardDaoImpl implements FreeboardDao {
 
 	// 의존성 주입
+	@Autowired
 	private SqlSession sqlSession;
 
 	// 추상 메소드 오버라이딩 - 등록할 게시글 번호 반환
@@ -20,6 +27,66 @@ public class FreeboardDaoImpl implements FreeboardDao {
 	// 추상 메소드 오버라이딩 - 자유게시판 게시글 등록
 	@Override
 	public void insertFreeboard(FreeboardDto freeboardDto) {
-		sqlSession.insert("freeboard.insert");
+		sqlSession.insert("freeboard.insert", freeboardDto);
+	}
+
+	// 추상 메소드 오버라이딩 - 자유게시글 조회
+	@Override
+	public List<FreeboardDto> searchFreeboard(FreeboardListSeachVO freeboardListSeachVO) {
+		// 검색 조회인지 판정
+		boolean isSearch = freeboardListSeachVO.isSearch();
+		if(isSearch) { // 검색 조회일 경우
+			return selectSearch(freeboardListSeachVO); // 검색 조회 메소드 결과 반환
+		}
+		else { // 검색 조회가 아닐 경우(전체 조회일 경우)
+			return selectAll(freeboardListSeachVO); // 전체 조회 메소드 결과 반환
+		}
+	}
+	
+	// 추상 메소드 오버라이딩 - 자유게시글 검색 조회
+	@Override
+	public List<FreeboardDto> selectSearch(FreeboardListSeachVO freeboardListSeachVO) {
+		// 바인딩 변수로 사용할 Map 생성
+		Map<String, String> param = new HashMap<>();
+		// 생성한 Map의 type과 keyword를 freeboardListSeachVO의 type과 keyword로 설정
+		param.put("type", freeboardListSeachVO.getType());
+		param.put("keyword", freeboardListSeachVO.getKeyword());
+		// Map을 바인딩 변수로 하여 검색 조회 후 결과 반환
+		return sqlSession.selectList("freeboard.searchList", param);
+	}
+	
+	// 추상 메소드 오버라이딩 - 자유게시글 전체 조회
+	@Override
+	public List<FreeboardDto> selectAll(FreeboardListSeachVO freeboardListSeachVO) {
+		// 전체 조회 후 결과 반환
+		return sqlSession.selectList("freeboard.allList");
+	}
+
+	// 추상 메소드 오버라이딩 - 자유게시글 상세 조회
+	@Override
+	public FreeboardDto detailFreeboard(int freeboardNo) {
+		// 단일 조회 후 결과 반환
+		return sqlSession.selectOne("freeboard.detail", freeboardNo);
+	}
+	
+	// 추상 메소드 오버라이딩 - 조회수 증가
+	@Override
+	public void updateFreeboardRead(int freeboardNo) {
+		// 조회수 증가
+		sqlSession.update("freeboard.updateRead", freeboardNo);
+	}
+	
+	// 추상 메소드 오버라이딩 - 자유게시글 수정
+	@Override
+	public boolean updateFreeboard(FreeboardDto freeboardDto) {
+		// 게시글 수정 후 수정 여부 반환
+		return sqlSession.update("freeboard.update", freeboardDto) > 0;
+	}
+
+	// 추상 메소드 오버라이딩 - 자유게시글 비활성화
+	@Override
+	public boolean inactiveFreeboard(int freeboardNo) {
+		// 상태 수정 후 수정 여부 반환
+		return sqlSession.update("freeboard.inactive", freeboardNo) > 0;
 	}
 }

--- a/ahzit/src/main/java/com/kh/ahzit/vo/FreeboardListSeachVO.java
+++ b/ahzit/src/main/java/com/kh/ahzit/vo/FreeboardListSeachVO.java
@@ -1,0 +1,19 @@
+package com.kh.ahzit.vo;
+
+import lombok.Data;
+
+@Data
+public class FreeboardListSeachVO {
+
+	// 검색 관련
+	// 필드
+	private String type;
+	private String keyword;
+	
+	// 메소드
+	// 검색 조회인지 여부 반환
+	public boolean isSearch() {
+		// 유형(type), 검색어(keyword) 둘다 null이 아니면 true를 반환
+		return type != null && keyword != null;
+	}
+}

--- a/ahzit/src/main/resources/mybatis/mapper/freeboard-mapper.xml
+++ b/ahzit/src/main/resources/mybatis/mapper/freeboard-mapper.xml
@@ -6,19 +6,44 @@
 
 <mapper namespace = "freeboard">
 
-	<!-- 등록을 위한 다음 게시글 번호 반환 -->
+	<!-- 등록을 위한 다음 자유 게시글 번호 반환 -->
 	<select id = "nextFreeboardNo" resultType = "int">
 		select freeboard_seq.nextval from dual
 	</select>
 	
-	<!-- 게시글 등록 -->
-	<insert id = "insert" parameterType = "String">
-		insert into freeboard(freeboard_no, freeboard_writer, freeboard_title, freeboard_content, freeboard_writedate) values(#{freeboardNo}, #{freeboardWriter}, #{freeboardTitle}, #{freeboardContent}, sysdate);
+	<!-- 자유 게시글 등록 -->
+	<insert id = "insert" parameterType = "FreeboardDto">
+		insert into freeboard(freeboard_no, freeboard_writer, freeboard_title, freeboard_content) values(#{freeboardNo}, #{freeboardWriter}, #{freeboardTitle}, #{freeboardContent})
 	</insert>
 	
-	<!-- 게시글 조회 -->
-	<select id = "allList" resultType = "FreeboardDto">
-		select freeboard_no, freeboard_writer, freeboard_title, freeboard_content, freeboard_read, freeboard_like, freeboard_writedate from freeboard order by freeboard_writedate
+	<!-- 자유 게시글 검색 조회 -->
+	<select id = "searchList" parameterType = "map" resultType = "FreeboardDto">
+		select freeboard_no, freeboard_writer, freeboard_title, freeboard_read, freeboard_like, freeboard_writedate from freeboard where instr(${type}, #{keyword}) > 0 and freeboard_state = 'N' order by freeboard_no desc
 	</select>
+	
+	<!-- 자유 게시글 전체 조회 -->
+	<select id = "allList" resultType = "FreeboardDto">
+		select freeboard_no, freeboard_writer, freeboard_title, freeboard_read, freeboard_like, freeboard_writedate from freeboard where freeboard_state = 'N' order by freeboard_no desc
+	</select>
+	
+	<!-- 자유 게시글 단일 조회 -->
+	<select id = "detail" parameterType = "int" resultType = "FreeboardDto">
+		select freeboard_no, freeboard_writer, freeboard_title, freeboard_read, freeboard_like, freeboard_content, freeboard_writedate from freeboard where freeboard_no = #{freeboardNo}
+	</select>
+	
+	<!-- 자유 게시글 조회수 증가 -->
+	<update id = "updateRead" parameterType = "int">
+		update freeboard set freeboard_read = freeboard_read + 1 where freeboard_no = #{freeboardNo}
+	</update>
+	
+	<!-- 자유 게시글 수정 -->
+	<update id = "update" parameterType = "FreeboardDto">
+		update freeboard set freeboard_title = #{freeboardTitle}, freeboard_content = #{freeboardContent}, freeboard_updatedate = sysdate where freeboard_no = #{freeboardNo}
+	</update>
+	
+	<!-- 자유 게시글 비활성화 -->
+	<update id = "inactive" parameterType = "int">
+		update freeboard set freeboard_state = 'Y' where freeboard_no = #{freeboardNo}
+	</update>
 	
 </mapper>

--- a/ahzit/src/main/webapp/WEB-INF/views/freeboard/detail.jsp
+++ b/ahzit/src/main/webapp/WEB-INF/views/freeboard/detail.jsp
@@ -1,0 +1,41 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+
+<%-- header --%>
+<jsp:include page="/WEB-INF/views/template/header.jsp">
+	<jsp:param value="자유게시판 - 게시글 상세" name="title"/>
+</jsp:include>
+
+<div class = "container">
+	<div class = "row">
+		게시글 번호 : ${freeboardDto.freeboardNo}
+	</div>
+	<div class = "row">
+		게시글 작성자 : ${freeboardDto.freeboardWriter}
+	</div>
+	<div class = "row">
+		게시글 제목 : ${freeboardDto.freeboardTitle}
+	</div>
+	<div class = "row">
+		게시글 내용 : ${freeboardDto.freeboardContent}
+	</div>
+	<div class = "row">
+		게시글 조회수 : ${freeboardDto.freeboardRead}
+	</div>
+	<div class = "row">
+		게시글 좋아요 : ${freeboardDto.freeboardLike}
+	</div>
+	<div class = "row">
+		게시글 작성일 : ${freeboardDto.freeboardWritedate}
+	</div>
+	<div>
+		<a href = "edit?freeboardNo=${freeboardDto.freeboardNo}">수정</a>
+		<a href = "inactive?freeboardNo=${freeboardDto.freeboardNo}">삭제</a>
+		<a href = "list">목록</a>
+	</div>
+</div>
+
+<%-- footer --%>
+<jsp:include page="/WEB-INF/views/template/footer.jsp"></jsp:include>

--- a/ahzit/src/main/webapp/WEB-INF/views/freeboard/edit.jsp
+++ b/ahzit/src/main/webapp/WEB-INF/views/freeboard/edit.jsp
@@ -1,0 +1,27 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<%-- header --%>
+<jsp:include page="/WEB-INF/views/template/header.jsp">
+	<jsp:param value="자유게시판 - 게시글 수정" name="title"/>
+</jsp:include>
+
+<div class = "container">
+	<form action = "edit" method = "post">
+		<input type = "hidden" name = "freeboardNo" value = "${freeboardDto.freeboardNo}">
+		<div class = "row">
+			제목 : <input type = "text" name = "freeboardTitle" value = "${freeboardDto.freeboardTitle}">
+		</div>
+		<div class = "row">
+			내용 : <input type = "text" name = "freeboardContent" value = "${freeboardDto.freeboardContent}">
+		</div>
+		<div class = "row">
+			<button type = "submit">수정</button>
+		</div>
+	</form>
+	<div class = "row">
+		<a href = "list">목록</a>		
+	</div>
+</div>
+
+<%-- footer --%>
+<jsp:include page="/WEB-INF/views/template/footer.jsp"></jsp:include>

--- a/ahzit/src/main/webapp/WEB-INF/views/freeboard/list.jsp
+++ b/ahzit/src/main/webapp/WEB-INF/views/freeboard/list.jsp
@@ -1,0 +1,56 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+
+<%-- header --%>
+<jsp:include page="/WEB-INF/views/template/header.jsp">
+	<jsp:param value="자유게시판 - 게시글 목록" name="title"/>
+</jsp:include>
+
+<table>
+	<thead>
+		<tr>
+			<th>번호</th>
+			<th>작성자</th>
+			<th>제목</th>
+			<th>조회수</th>
+			<th>좋아요</th>
+			<th>작성일</th>
+		</tr>
+	</thead>
+	<tbody>
+		<c:forEach var = "list" items = "${freeboardList}">
+			<tr>
+				<td>${list.freeboardNo}</td>
+				<td>${list.freeboardWriter}</td>
+				<td>
+					<a href = "detail?freeboardNo=${list.freeboardNo}">${list.freeboardTitle}</a>
+				</td>
+				<td>${list.freeboardRead}</td>
+				<td>${list.freeboardLike}</td>
+				<td>${list.freeboardWritedate}</td>
+			</tr>
+		</c:forEach>
+	</tbody>
+	<tfoot>
+		<tr class = "right" >
+			<td colspan="6">
+				<a href = "write">게시글 작성</a>
+			</td>
+		</tr>
+	</tfoot>
+</table>
+
+<%-- 검색창 --%>
+<form action = "list" method = "get">
+	<select name = "type" required>
+		<option value = "freeboard_title">제목</option>
+		<option value = "freeboard_content">내용</option>
+	</select>
+	<input name = "keyword" placeholder = "검색어" value = "${freeboardListSeachVO.keyword}">
+	<button type = "submit">검색</button>
+</form>
+
+<%-- footer --%>
+<jsp:include page="/WEB-INF/views/template/footer.jsp"></jsp:include>

--- a/ahzit/src/main/webapp/WEB-INF/views/freeboard/write.jsp
+++ b/ahzit/src/main/webapp/WEB-INF/views/freeboard/write.jsp
@@ -1,19 +1,24 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
 
-<!-- header -->
+<%-- header --%>
 <jsp:include page="/WEB-INF/views/template/header.jsp">
 	<jsp:param value="자유게시판 - 게시글 작성" name="title"/>
 </jsp:include>
 
 <h1>자유 게시판 - 게시글 작성</h1>
 
-<form action = "write" method = "post">
-	제목 : <input type = "text" name = "freeboardTitle">
-	<br>
-	내용 : <textarea name = "freeboardContent"></textarea>
-	<button type = "submit">작성</button>
-</form>
+<div class = "container">
+	<form action = "write" method = "post">
+		<div class = "row">
+			제목 : <input type = "text" name = "freeboardTitle">
+		</div>
+		<div class = "row">
+			제목 : <input type = "text" name = "freeboardTitle">
+		</div>
+		<button type = "submit">작성</button>
+	</form>
+</div>
 
-<!-- footer -->
+<%-- footer --%>
 <jsp:include page="/WEB-INF/views/template/footer.jsp"></jsp:include>

--- a/ahzit/src/main/webapp/WEB-INF/views/home.jsp
+++ b/ahzit/src/main/webapp/WEB-INF/views/home.jsp
@@ -2,9 +2,12 @@
     pageEncoding="UTF-8"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 
-<%-- header.jsp 불러오기 --%>
+<%-- header --%>
 <jsp:include page="/WEB-INF/views/template/header.jsp">
 	<jsp:param value="메인페이지" name="title"/>
 </jsp:include>
 
 <h1>홈 화면</h1>
+
+<%-- footer --%>
+<jsp:include page="/WEB-INF/views/template/footer.jsp"></jsp:include>

--- a/ahzit/src/main/webapp/WEB-INF/views/template/header.jsp
+++ b/ahzit/src/main/webapp/WEB-INF/views/template/header.jsp
@@ -6,7 +6,25 @@
 <html>
 <head>
 <meta charset="UTF-8">
-<title>Insert title here</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+	
+	<!-- Bootstrap CDN -->
+	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+	
+<title>
+	<c:choose>
+		<%-- title이라는 변수의 값이 있다면(null이 아니면) title에 입력될 값은 해당 title 변수의 값으로  --%>
+		<c:when test = "${param.title != null}">
+			${param.title}
+		</c:when>
+		<c:otherwise>
+			Ahzit
+		</c:otherwise>
+	</c:choose>
+</title>
 </head>
 <body>
 
@@ -30,3 +48,5 @@
 <div>
 	<a href = "/freeboard/list">자유게시판</a>
 </div>
+
+<hr>

--- a/ahzit/src/test/java/com/kh/ahzit/Test_Luverduck.java
+++ b/ahzit/src/test/java/com/kh/ahzit/Test_Luverduck.java
@@ -1,7 +1,12 @@
 package com.kh.ahzit;
 
+import org.apache.ibatis.session.SqlSession;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import com.kh.ahzit.entity.FreeboardDto;
+import com.kh.ahzit.repository.FreeboardDao;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -9,10 +14,25 @@ import lombok.extern.slf4j.Slf4j;
 @SpringBootTest
 public class Test_Luverduck {
 
+	// 의존성 주입
+	@Autowired
+	private SqlSession sqlSession;
+	
+	// 의존성 주입
+	@Autowired
+	private FreeboardDao freeboardDao;
+	
+//	게시글 등록	
 	@Test
 	public void test() {
-		int a = 1;
-		int b = 2; 
-		int c = 1;
+		for(int i = 0 ; i < 50 ; i ++) {
+			int freeboardNo = freeboardDao.nextFreeboardNo();
+			sqlSession.insert("freeboard.insert", FreeboardDto.builder()
+					.freeboardNo(freeboardNo)
+					.freeboardWriter("test1231")
+					.freeboardTitle("테스트제목 " + i)
+					.freeboardContent("테스트내용 " + i)
+					.build());
+		}
 	}
 }


### PR DESCRIPTION
freeboard-mapper.xml
- 게시글 등록에서 작성일자 항목 제거
- 게시글 통합 조회(전체/검색), 단일조회, 수정, 비활성화 구현

FreeboardListSearchVO
- 통합 조회(전체/검색)를 위한 VO 생성

FreeboardDao, FreeboardDaoImpl
- 게시글 통합 조회(전체/검색), 단일조회, 수정, 비활성화 구현

FreeboardController
- 게시글 등록 DB 처리 Mapping에서 반환한 회원 아이디 변수명 변경
- 게시글 목록 Mapping 생성
- 게시글 상세 Mapping 생성
- 게시글 수정 페이지 및 수정 DB 처리 Mapping 생성
- 게시글 비활성화 Mapping 생성

freeboard/write.jsp
- 게시글 작성 페이지에 Bootstrap을 이용하여 기본적인 틀 생성

freeboard/list.jsp
- 게시글 목록 페이지 생성

freeboard/detail.jsp
- 게시글 상세 페이지 생성

freeboard/edit.jsp
- 게시글 수정 페이지 생성

home.jsp
- footer 적용

header.jsp
- 기본적인 틀을 잡기 위해 Bootstrap CDN과 CSS 추가 및 header 경계를 위한 <br> 태그 삽입