### PR TITLE
작업 내용

### DIFF
--- a/ahzit/src/main/java/com/kh/ahzit/controller/HomeController.java
+++ b/ahzit/src/main/java/com/kh/ahzit/controller/HomeController.java
@@ -14,6 +14,7 @@ import com.kh.ahzit.constant.SessionConstant;
 import com.kh.ahzit.repository.AhzitDao;
 import com.kh.ahzit.repository.AhzitUserDao;
 import com.kh.ahzit.vo.AhzitSearchListRequestVO;
+import com.kh.ahzit.vo.AhzitSearchListResponseVO;
 import com.kh.ahzit.vo.MyAhzitVO;
 
 
@@ -54,9 +55,10 @@ public class HomeController {
 
  		int total = ahzitDao.countselectAhzit(ahzitSearchListRequestVO);
  		ahzitSearchListRequestVO.setTotal(total);
- 		List<AhzitSearchListRequestVO> searchSortAhzit = ahzitDao.selectSortAhzit(ahzitSearchListRequestVO);
- 		//System.out.println(allAhzitList);
+ 		List<AhzitSearchListResponseVO> searchSortAhzit = ahzitDao.selectSortAhzit(ahzitSearchListRequestVO);
+ 		//System.out.println(searchSortAhzit);
  	//	System.out.println(total);
+ 		model.addAttribute("pLast", ahzitSearchListRequestVO.blockLast());
  		model.addAttribute("searchSortAhzit", searchSortAhzit);
  		return "ahzit/search";
  	}

--- a/ahzit/src/main/java/com/kh/ahzit/repository/AhzitDao.java
+++ b/ahzit/src/main/java/com/kh/ahzit/repository/AhzitDao.java
@@ -66,13 +66,13 @@ public interface AhzitDao {
 	public int searchMemberCount(int ahzitNo, String keyword);
 
 	// 추상 메소드 - 찾기 페이지에서 소모임 조회
-	List<AhzitSearchListRequestVO> selectSortAhzit(AhzitSearchListRequestVO ahzitSearchListRequestVO);
+	List<AhzitSearchListResponseVO> selectSortAhzit(AhzitSearchListRequestVO ahzitSearchListRequestVO);
 	
 	// 추상 메소드 - 찾기 페이지에서 전체 소모임 조회
-	List<AhzitSearchListRequestVO> allSortAhzit(AhzitSearchListRequestVO ahzitSearchListRequestVO);
+	List<AhzitSearchListResponseVO> allSortAhzit(AhzitSearchListRequestVO ahzitSearchListRequestVO);
 	
 	// 추상 메소드 - 찾기 페이지에서 특정 카테고리 소모임 조회
-	List<AhzitSearchListRequestVO> searchSortAhzit(AhzitSearchListRequestVO ahzitSearchListRequestVO);
+	List<AhzitSearchListResponseVO> searchSortAhzit(AhzitSearchListRequestVO ahzitSearchListRequestVO);
 		
 	// 추상 메소드 - 찾기 페이지에서 소모임 갯수
 	public int countselectAhzit(AhzitSearchListRequestVO ahzitSearchListRequestVO);

--- a/ahzit/src/main/java/com/kh/ahzit/repository/AhzitDaoImpl.java
+++ b/ahzit/src/main/java/com/kh/ahzit/repository/AhzitDaoImpl.java
@@ -213,7 +213,7 @@ public class AhzitDaoImpl implements AhzitDao {
 	
 	// 추상 메소드 - 찾기 페이지에서 소모임 조회
 	@Override
-	public List<AhzitSearchListRequestVO> selectSortAhzit(AhzitSearchListRequestVO ahzitSearchListRequestVO) {
+	public List<AhzitSearchListResponseVO> selectSortAhzit(AhzitSearchListRequestVO ahzitSearchListRequestVO) {
 		if(ahzitSearchListRequestVO.isSearch()) {
 			return searchSortAhzit(ahzitSearchListRequestVO);
 		}
@@ -224,7 +224,7 @@ public class AhzitDaoImpl implements AhzitDao {
 	
 	// 추상 메소드 - 찾기 페이지에서 전체 소모임 조회
 	@Override
-	public List<AhzitSearchListRequestVO> allSortAhzit(AhzitSearchListRequestVO ahzitSearchListRequestVO) {
+	public List<AhzitSearchListResponseVO> allSortAhzit(AhzitSearchListRequestVO ahzitSearchListRequestVO) {
 		Map<String, String> param = new HashMap<>();	
 		param.put("rownumStart", String.valueOf(ahzitSearchListRequestVO.rownumStart()));
 		param.put("rownumEnd", String.valueOf(ahzitSearchListRequestVO.rownumEnd()));
@@ -233,7 +233,7 @@ public class AhzitDaoImpl implements AhzitDao {
 
 	// 추상 메소드 - 찾기 페이지에서 특정 카테고리 소모임 조회
 	@Override
-	public List<AhzitSearchListRequestVO> searchSortAhzit(AhzitSearchListRequestVO ahzitSearchListRequestVO) {
+	public List<AhzitSearchListResponseVO> searchSortAhzit(AhzitSearchListRequestVO ahzitSearchListRequestVO) {
 		Map<String, String> param = new HashMap<>();	
 		param.put("keyword", ahzitSearchListRequestVO.getKeyword());
 		param.put("rownumStart", String.valueOf(ahzitSearchListRequestVO.rownumStart()));

--- a/ahzit/src/main/java/com/kh/ahzit/restcontroller/AhzitRestController.java
+++ b/ahzit/src/main/java/com/kh/ahzit/restcontroller/AhzitRestController.java
@@ -1,0 +1,61 @@
+package com.kh.ahzit.restcontroller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kh.ahzit.repository.AhzitDao;
+import com.kh.ahzit.vo.AhzitSearchListRequestVO;
+import com.kh.ahzit.vo.AhzitSearchListResponseVO;
+import com.kh.ahzit.vo.AhzitSearchListRestResponseVO;
+
+@RestController
+@RequestMapping("/rest_ahzit")
+public class AhzitRestController {
+
+	// 의존성 주입
+	@Autowired
+	private AhzitDao ahzitDao;
+	
+	// 찾기 페이지에서 소모임 조회
+	@GetMapping("/search")
+	public AhzitSearchListRestResponseVO searchAhzit(@RequestParam(required=false) String keyword, @RequestParam int cntRow, @RequestParam int p){
+		// 반환 VO 생성
+		AhzitSearchListRestResponseVO ahzitSearchListRestResponseVO = new AhzitSearchListRestResponseVO();
+		// 요청 VO 생성
+		AhzitSearchListRequestVO ahzitSearchListRequestVO = new AhzitSearchListRequestVO();
+		ahzitSearchListRequestVO.setP(p);
+		ahzitSearchListRequestVO.setCntRow(cntRow);
+		int total;
+		List<AhzitSearchListResponseVO> ahzitInfoList;
+		if(keyword != null) {
+			ahzitSearchListRequestVO.setKeyword(keyword);
+			total = ahzitDao.countselectAhzit(ahzitSearchListRequestVO);
+			// 총 갯수를 요청 VO의 총 갯수에 설정에 설정
+			ahzitSearchListRequestVO.setTotal(total);
+			// 조회 결고 반환
+			ahzitInfoList = ahzitDao.selectSortAhzit(ahzitSearchListRequestVO);
+		}
+		else {
+			total = ahzitDao.countAllAhzit(ahzitSearchListRequestVO);
+			// 총 갯수를 요청 VO의 총 갯수에 설정에 설정
+			ahzitSearchListRequestVO.setTotal(total);
+			// 조회 결고 반환
+			ahzitInfoList = ahzitDao.allSortAhzit(ahzitSearchListRequestVO);
+		}
+		// 반환 VO에 조회 결과를 설정
+		ahzitSearchListRestResponseVO.setAhzitInfoList(ahzitInfoList);
+		// 반환 VO에 조회한 총 소모임 갯수 설정
+		ahzitSearchListRestResponseVO.setInfoCount(total);
+		// 반환 VO에 조회한 총 소모임의 마지막 페이지 블럭 설정
+		ahzitSearchListRestResponseVO.setPLast(ahzitSearchListRequestVO.blockLast());		
+		// 설정된 반환 VO를 반환
+		return ahzitSearchListRestResponseVO;
+	}
+	 
+	
+}

--- a/ahzit/src/main/java/com/kh/ahzit/vo/AhzitSearchListRequestVO.java
+++ b/ahzit/src/main/java/com/kh/ahzit/vo/AhzitSearchListRequestVO.java
@@ -15,7 +15,7 @@ public class AhzitSearchListRequestVO {
 	
 	// 페이징 관련
 	private int p = 1; // 페이지 번호(페이지 로드시 초기 페이지를 1로 하기 위해 초기값을 1로 설정)
-	private int cntRow = 9;  // 한 페이지에 표시할 열 갯수 (고정값)
+	private int cntRow = 6;  // 한 페이지에 표시할 열 갯수 (고정값)
 	
 	// 메소드
 	// - 게시글 열 시작 번호

--- a/ahzit/src/main/java/com/kh/ahzit/vo/AhzitSearchListRestResponseVO.java
+++ b/ahzit/src/main/java/com/kh/ahzit/vo/AhzitSearchListRestResponseVO.java
@@ -1,0 +1,14 @@
+package com.kh.ahzit.vo;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class AhzitSearchListRestResponseVO {
+
+	// 필드
+	private List<AhzitSearchListResponseVO> ahzitInfoList;
+	private int pLast;
+	private int infoCount;
+}

--- a/ahzit/src/main/resources/mybatis/mapper/ahzit-mapper.xml
+++ b/ahzit/src/main/resources/mybatis/mapper/ahzit-mapper.xml
@@ -13,7 +13,7 @@
   		<insert id="insert" parameterType="AhzitDto" >
   			insert into ahzit(
   			ahzit_no, ahzit_leader, ahzit_sort, ahzit_name, ahzit_info, ahzit_region_high, ahzit_region_low, ahzit_ispublic) 
-  			values (#{ahzitNo}, #{ahzitLeader}, #{ahzitSort}, #{ahzitName}, #{ahzitInfo}, #{ahzitRegionHigh}, #{ahzitRegionLow}, #{ahzitIsPublic})
+  			values (#{ahzitNo}, #{ahzitLeader}, #{ahzitSort}, #{ahzitName}, #{ahzitInfo}, #{ahzitRegionHigh}, #{ahzitRegionLow}, #{ahzitIspublic})
   		</insert>
   		
   		<!-- 소모임 목록 -->
@@ -33,7 +33,7 @@
 	  				ahzit_name = #{ahzitName} , 
 	  				ahzit_info = #{ahzitInfo}, 
 	  				ahzit_headmax = #{ahzitHeadMax}, 
-	  				ahzit_isPublic = #{ahzitIsPublic}
+	  				ahzit_isPublic = #{ahzitIspublic}
 	  			where
 	  				ahzit_no = #{ahzitNo}
   		 </update>
@@ -53,12 +53,12 @@
 		
 		<!-- 찾기 페이지에서 전체 소모임 조회 -->
 		<select id = "allSort" parameterType = "map" resultType = "AhzitSearchListResponseVO">
-			select * from (select tmp.*, rownum rn from (select aa.ahzit_attachment_no, a.* from ahzit a left outer join ahzit_attachment aa on a.ahzit_no = ahzit_origin_no where ahzit_state = 'N' and ahzit_ispublic = 'N')tmp) where rn between #{rownumStart} and #{rownumEnd}
+			select * from (select tmp.*, rownum rn from (select aa.ahzit_attachment_no, a.* from ahzit a left outer join ahzit_attachment aa on a.ahzit_no = ahzit_origin_no where ahzit_state = 'N' and ahzit_ispublic = 'N' order by ahzit_no desc)tmp) where rn between #{rownumStart} and #{rownumEnd}
 		</select>
 		
 		<!-- 찾기 페이지에서 특정 카테고리 소모임 조회 -->
 		<select id = "searchSort" parameterType = "map" resultType = "AhzitSearchListResponseVO">
-			select * from (select tmp.*, rownum rn from (select aa.ahzit_attachment_no, a.* from ahzit a left outer join ahzit_attachment aa on a.ahzit_no = ahzit_origin_no where ahzit_state = 'N' and ahzit_ispublic = 'N' and instr(ahzit_sort, #{keyword}) > 0)tmp) where rn between #{rownumStart} and #{rownumEnd}
+			select * from (select tmp.*, rownum rn from (select aa.ahzit_attachment_no, a.* from ahzit a left outer join ahzit_attachment aa on a.ahzit_no = ahzit_origin_no where ahzit_state = 'N' and ahzit_ispublic = 'N' and instr(ahzit_sort, #{keyword}) > 0 order by ahzit_no desc)tmp) where rn between #{rownumStart} and #{rownumEnd}
 		</select>
 		
 		<!-- 홈 화면의 검색창 전체 조회 -->

--- a/ahzit/src/main/webapp/WEB-INF/views/ahzit/edit.jsp
+++ b/ahzit/src/main/webapp/WEB-INF/views/ahzit/edit.jsp
@@ -67,8 +67,8 @@
 		<p>아지트 공개 여부</p>
 		<p>현재 상태 : ${ahzitDto.ahzitIspublic}</p>
 		<div>
-			<input type="radio" name="ahzitIsPublic" value="Y" checked><label>비공개 아지트</label>
-			<input type="radio" name="ahzitIsPublic" value="N"><label>공개 아지트</label><br><br> <%-- 공개를 N으로 하기로 함 --%>
+			<input type="radio" name="ahzitIspublic" value="N"><label>공개 아지트</label><br><br> <%-- 공개를 N으로 하기로 함 --%>
+			<input type="radio" name="ahzitIspublic" value="Y" checked><label>비공개 아지트</label>
 		</div>
 	</div>
 

--- a/ahzit/src/main/webapp/WEB-INF/views/ahzit/search.jsp
+++ b/ahzit/src/main/webapp/WEB-INF/views/ahzit/search.jsp
@@ -8,6 +8,10 @@
 </jsp:include>
 
 <style>
+	* {
+		border: 1px dotted gray;
+	}
+	
    	.ahzit-img {
    		width:100%;
    		height:300px;
@@ -137,7 +141,7 @@
 		<div class = "col-8 offset-2">
 
 			<div class="row mt-4">
-				<div class="col-lg-4 offset-lg-4 col-md-6 offset-md-3 col-sm-8 offset-sm-2">
+				<div class="col-lg-4 offset-lg-4 col-md-6 offset-md-3 col-sm-8 offset-sm-2 div-search-plast" data-plast = "${pLast}">
 					<div class="p-4 rounded">
 						<h1 class="text-center">아지트</h1>	
 					</div>
@@ -146,82 +150,113 @@
 			
 			<div class = "row mt-4">
 				<div class = "col">
-					<a href="search"><img src="/images/search.png" class="sort-img mb-2 ms-4"><p class="text-center">전체</p></a>
+					<div class = "d-flex justify-content-top align-items-center flex-column div-search-keyword" onclick="location.href='search';" data-keyword = "">
+						<img src="/images/search.png" class="sort-img mb-1">
+						<p class="text-center">전체</p>
+					</div>
 				</div>	
-
 				<div class = "col">
-					<a href="search?keyword=취미"><img src="/images/hobbies.png" class="sort-img mb-2 ms-4"><p class="text-center">취미</p></a>
+					<div class = "d-flex justify-content-top align-items-center flex-column div-search-keyword" onclick="location.href='search?keyword=취미';" data-keyword="취미">
+						<img src="/images/hobbies.png" class="sort-img mb-1">
+						<p class="text-center">취미</p>
+					</div>
 				</div>
 			
 				<div class = "col">
-					<a href="search?keyword=스터디"> <img src="/images/study.png" class="sort-img mb-2 mb-1 ms-4"><p class="text-center">스터디</p></a>
+					<div class = "d-flex justify-content-top align-items-center flex-column div-search-keyword" onclick="location.href='search?keyword=스터디';" data-keyword="스터디">
+						<img src="/images/study.png" class="sort-img mb-1">
+						<p class="text-center">스터디</p>
+					</div>
 				</div>
 				
 				<div class = "col">
-          			<a href="search?keyword=일상"><img src="/images/life-smile.png" class="sort-img mb-2 mb-1 ms-4"><p class="text-center">일상</p></a>
-				</div>
-			
-				<div class = "col">
-					<a href="search?keyword=팬클럽"><img src="/images/fanclub.png" class="sort-img mb-2 mb-1 ms-4"><p class="text-center">팬클럽</p></a>
-				</div>
-				
-				<div class = "col">
-					<a href="search?keyword=음악"><img src="/images/music.png" class="sort-img mb-2 ms-4"><p class="text-center">음악</p></a>
+					<div class = "d-flex justify-content-top align-items-center flex-column div-search-keyword" onclick="location.href='search?keyword=스터디';" data-keyword="일상">
+						<img src="/images/life-smile.png" class="sort-img mb-1">
+						<p class="text-center">일상</p>
+					</div>
 				</div>
 				
 				<div class = "col">
-					<a href="search?keyword=스포츠"><img src="/images/sports.png" class="sort-img mb-2 ms-4"><p class="text-center">스포츠</p></a>
+					<div class = "d-flex justify-content-top align-items-center flex-column div-search-keyword" onclick="location.href='search?keyword=팬클럽';" data-keyword="팬클럽">
+						<img src="/images/fanclub.png" class="sort-img mb-1">
+						<p class="text-center">팬클럽</p>
+					</div>
 				</div>
 				
 				<div class = "col">
-					<a href="search?keyword=여행"><img src="/images/travel.png" class="sort-img mb-2 ms-4"><p class="text-center">여행</p></a>
+					<div class = "d-flex justify-content-top align-items-center flex-column div-search-keyword" onclick="location.href='search?keyword=음악';" data-keyword="음악">
+						<img src="/images/music.png" class="sort-img mb-1">
+						<p class="text-center">음악</p>
+					</div>
 				</div>
 				
 				<div class = "col">
-					<a href="search?keyword=맛집"><img src="/images/eat.png" class="sort-img mb-2 ms-4"><p class="text-center">맛집</p></a>
+					<div class = "d-flex justify-content-top align-items-center flex-column div-search-keyword" onclick="location.href='search?keyword=스포츠';" data-keyword="스포츠">
+						<img src="/images/sports.png" class="sort-img mb-1">
+						<p class="text-center">스포츠</p>
+					</div>
 				</div>
 				
 				<div class = "col">
-					<a href="search?keyword=영화"><img src="/images/movie.png" class="sort-img mb-2 ms-4"><p class="text-center">영화</p></a>
+					<div class = "d-flex justify-content-top align-items-center flex-column div-search-keyword" onclick="location.href='search?keyword=여행';" data-keyword="여행">
+						<img src="/images/travel.png" class="sort-img mb-1">
+						<p class="text-center">여행</p>
+					</div>
+				</div>
+				
+				<div class = "col">
+					<div class = "d-flex justify-content-top align-items-center flex-column div-search-keyword" onclick="location.href='search?keyword=맛집';" data-keyword="맛집">
+						<img src="/images/eat.png" class="sort-img mb-1">
+						<p class="text-center">맛집</p>
+					</div>
+				</div>
+				
+				<div class = "col">
+					<div class = "d-flex justify-content-top align-items-center flex-column div-search-keyword" onclick="location.href='search?keyword=영화';" data-keyword="영화">
+						<img src="/images/movie.png" class="sort-img mb-1">
+						<p class="text-center">영화</p>
+					</div>	
 				</div>	
 			</div>
+				
 					
 	
-		 <div class="row">
-			<c:forEach var="searchSortAhzit" items="${searchSortAhzit}"> <!-- 반복문 시작 -->
-			 <div class="mt-4 col-xl-4 col-lg-6 col-md-6 col-sm-6" id="div-ahzit-info">
-	              <div class="card-sl">
-	                  <div class="card-image">  <%--아지트 이미지 --%>
-	                      <img src = "/attachment/download/ahzit?attachmentNo=${searchSortAhzit.ahzitAttachmentNo}"  onerror=" this.onerror=null; this.src='/images/bg_default.jpg';" class="ahzit-img">
-	                  </div>
-	                  <a class="card-action" href="${pageContext.request.contextPath}/ahzit_in/${searchSortAhzit.ahzitNo}">
-	                  <%--아지트 종류에 따른 아이콘 --%>
-	                  <c:if test="${searchSortAhzit.ahzitSort == '취미'}"><img src="/images/hobbies.png"  class="sort-img"></c:if>
-	                  <c:if test="${searchSortAhzit.ahzitSort == '스터디'}"><img src="/images/study.png"  class="sort-img"></c:if>
-	                  <c:if test="${searchSortAhzit.ahzitSort == '일상'}"><img src="/images/life-smile.png"  class="sort-img"></c:if>
-	                  <c:if test="${searchSortAhzit.ahzitSort == '팬클럽'}"><img src="/images/fanclub.png"  class="sort-img"></c:if>
-	                  <c:if test="${searchSortAhzit.ahzitSort == '음악'}"><img src="/images/music.png"  class="sort-img"></c:if>
-	                  <c:if test="${searchSortAhzit.ahzitSort == '스포츠'}"><img src="/images/sports.png"  class="sort-img"></c:if>
-	                  <c:if test="${searchSortAhzit.ahzitSort == '여행'}"><img src="/images/travel.png"  class="sort-img"></c:if>
-	                  <c:if test="${searchSortAhzit.ahzitSort == '맛집'}"><img src="/images/eat.png"  class="sort-img"></c:if>
-	                  <c:if test="${searchSortAhzit.ahzitSort == '영화'}"><img src="/images/movie.png"  class="sort-img"></c:if>
-	                  </a>
-	                  <div class="card-heading"> <%--아지트 이름 --%>
-	                      ${searchSortAhzit.ahzitName} 
-	                  </div>
-	                  <div class="card-text-1">  <%--아지트 멤버 수 , 종류 --%>
-	                      <span class = "span-ahzit-head">${searchSortAhzit.ahzitHead}</span> 
-	                      /
-	                      <span class = "span-ahzit-headmax">${searchSortAhzit.ahzitHeadmax}</span>
-	                      &nbsp; 
-	                      <span class = "span-ahzit-sort">#${searchSortAhzit.ahzitSort}</span>
-	                  </div>
-	                  <div class="card-text-2"> <%--아지트 지역 --%>
-	                    <i class="fa-solid fa-location-dot"></i> ${searchSortAhzit.ahzitRegionHigh} ${searchSortAhzit.ahzitRegionLow} 
-	                  </div>
-	              </div>
-             </div>
-			 </c:forEach> <!-- 반복문 끝 -->
+			 <div class="row div-ahzit-list"> <%-- 태그 붙이는 타겟 --%>
+				<c:forEach var="searchSortAhzit" items="${searchSortAhzit}"> <!-- 반복문 시작 -->
+				<div class="mt-4 col-xl-4 col-lg-6 col-md-6 col-sm-6" id="div-ahzit-info">
+		        	<div class="card-sl">
+		            	<div class="card-image">  <%--아지트 이미지 --%>
+		                	<img src = "/attachment/download/ahzit?attachmentNo=${searchSortAhzit.ahzitAttachmentNo}" onerror="this.onerror=null; this.src='/images/bg_default.jpg';" class="ahzit-img">
+		               	</div>
+		                <a class="card-action" href="${pageContext.request.contextPath}/ahzit_in/${searchSortAhzit.ahzitNo}">
+		                <%--아지트 종류에 따른 아이콘 --%>
+		                <c:if test="${searchSortAhzit.ahzitSort == '취미'}"><img src="/images/hobbies.png"  class="sort-img"></c:if>
+		                <c:if test="${searchSortAhzit.ahzitSort == '스터디'}"><img src="/images/study.png"  class="sort-img"></c:if>
+		                <c:if test="${searchSortAhzit.ahzitSort == '일상'}"><img src="/images/life-smile.png"  class="sort-img"></c:if>
+		                <c:if test="${searchSortAhzit.ahzitSort == '팬클럽'}"><img src="/images/fanclub.png"  class="sort-img"></c:if>
+		                <c:if test="${searchSortAhzit.ahzitSort == '음악'}"><img src="/images/music.png"  class="sort-img"></c:if>
+		                <c:if test="${searchSortAhzit.ahzitSort == '스포츠'}"><img src="/images/sports.png"  class="sort-img"></c:if>
+		                <c:if test="${searchSortAhzit.ahzitSort == '여행'}"><img src="/images/travel.png"  class="sort-img"></c:if>
+		                <c:if test="${searchSortAhzit.ahzitSort == '맛집'}"><img src="/images/eat.png"  class="sort-img"></c:if>
+		                <c:if test="${searchSortAhzit.ahzitSort == '영화'}"><img src="/images/movie.png"  class="sort-img"></c:if>
+		                </a>
+		                <div class="card-heading"> <%--아지트 이름 --%>
+		                    ${searchSortAhzit.ahzitName} 
+		                </div>
+		                <div class="card-text-1">  <%--아지트 멤버 수 , 종류 --%>
+		                    <span class = "span-ahzit-head">${searchSortAhzit.ahzitHead}</span> 
+		                    /
+		                    <span class = "span-ahzit-headmax">${searchSortAhzit.ahzitHeadmax}</span>
+		                    &nbsp; 
+		                    <span class = "span-ahzit-sort">#${searchSortAhzit.ahzitSort}</span>
+		                </div>
+		            	<div class="card-text-2"> <%--아지트 지역 --%>
+		                  	<i class="fa-solid fa-location-dot"></i> 
+		                  	<span class = "span-ahzit-location">${searchSortAhzit.ahzitRegionHigh} ${searchSortAhzit.ahzitRegionLow}</span>
+		            	</div>
+		        	</div>
+	            </div>
+				</c:forEach> <!-- 반복문 끝 -->
 			</div>
 		</div>
 	</div>
@@ -230,14 +265,23 @@
 
 <script type="text/javascript">
 	
-	//초기 1페이지
+	//현재 주소
+	var url_href = window.location.href;
+	var url = new URL(url_href);
+	
+	// 요청 파라미터 변수화
+	var keyword = url.searchParams.get("keyword");
+	console.log(keyword);
+	
+	// 초기 1페이지
 	var p = 1;
 	
-	// 초기 검색어
-	var keyword = "";
+	// 특정 카테고리의 총 소모임 수
+	var pLast = $(".div-search-plast").data("plast");
+	//console.log(pLast);
 	
-	// 총 소모임 수
-	var pLast;
+	// 무한스크롤 시 3개씩만 불러오기
+	var cntRow = 3;
 	
 	$(function(){
 		
@@ -250,13 +294,100 @@
 			
 			// 화면 총 길이의 80%에 도달했을 때
 			if(percentage > 80) {
-				// 페이지 수 증가
-				p = p + 1;
-				var ahzitNo = $("#div-member-info").data("ahzitno");
-				var memberNo = $("#div-member-info").data("memberno");
+				
+				// 태그 붙일 타겟 지정
+				var target = $(".div-ahzit-list");
+				
+				var url;
+				if(keyword != null) {
+					url = "http://localhost:8888/rest_ahzit/search?p=" + p + "&cntRow=" + cntRow + "keyword=" + keyword;
+				} else {
+					url = "http://localhost:8888/rest_ahzit/search?p=" + p + "&cntRow=" + cntRow;
+				}
+				
+				axios({
+					url : url,
+					method : "get"
+				})
+				.then(function(response){
+					// 페이지 수 증가
+					p = p + 1;
+					console.log(response);
+					for(var i = 0 ; i < response.data.ahzitInfoList.length ; i ++) {
+						// 1
+						var div_outer_container = $("<div>").attr("class", "mt-4 col-xl-4 col-lg-6 col-md-6 col-sm-6");
+						// 2
+						var div_inner_container = $("<div>").attr("class", "card-sl");
+						
+						var div_ahzit_img_container = $("<div>").attr("class", "card-image");
+						
+						var img_ahzit_img_img;
+						if(response.data.ahzitInfoList[i].ahzitAttachmentNo != 0) {
+							img_ahzit_img_img = $("<img>").attr("src", "/attachment/download/ahzit?attachmentNo=" + response.data.ahzitInfoList[i].ahzitAttachmentNo).attr("class", "ahzit-img");
+						} else {
+							img_ahzit_img_img = $("<img>").attr("src", "${pageContext.request.contextPath}/images/bg_default.jpg").attr("class", "ahzit-img");
+						}
+						// 3-1)
+						var div_ahzit_img = div_ahzit_img_container.append(img_ahzit_img_img);
+						
+						var a_ahzit_href_container = $("<a>").attr("class", "card-action").attr("href", "${pageContext.request.contextPath}/ahzit_in/" + response.data.ahzitInfoList[i].ahzitNo);
+						
+						var img_ahzit_category;
+						if(response.data.ahzitInfoList[i].ahzitSort == "취미") {
+							img_ahzit_category = $("<img>").attr("src", "/images/hobbies.png").attr("class", "sort-img");
+						} else if(response.data.ahzitInfoList[i].ahzitSort == "스터디") {
+							img_ahzit_category = $("<img>").attr("src", "/images/study.png").attr("class", "sort-img");
+						} else if(response.data.ahzitInfoList[i].ahzitSort == "일상") {
+							img_ahzit_category = $("<img>").attr("src", "/images/life-smile.png").attr("class", "sort-img");
+						} else if(response.data.ahzitInfoList[i].ahzitSort == "팬클럽") {
+							img_ahzit_category = $("<img>").attr("src", "/images/fanclub.png").attr("class", "sort-img");
+						} else if(response.data.ahzitInfoList[i].ahzitSort == "음악") {
+							img_ahzit_category = $("<img>").attr("src", "/images/music.png").attr("class", "sort-img");
+						} else if(response.data.ahzitInfoList[i].ahzitSort == "스포츠") {
+							img_ahzit_category = $("<img>").attr("src", "/images/sports.png").attr("class", "sort-img");
+						} else if(response.data.ahzitInfoList[i].ahzitSort == "여행") {
+							img_ahzit_category = $("<img>").attr("src", "/images/eat.png").attr("class", "sort-img");
+						}
+						
+						// 3-2)
+						var a_ahzit_href = a_ahzit_href_container.append(img_ahzit_category);
+						
+						// 3-3)
+						var div_card_heading = $("<div>").attr("class", "card-heading").text(response.data.ahzitInfoList[i].ahzitName);
+						
+						var div_card_text_1_container = $("<div>").attr("class", "card-text-1");
+						var span_ahzit_head = $("<span>").attr("class", "ahzit-head").text(response.data.ahzitInfoList[i].ahzitHead + " / ");
+						var span_ahzit_headmax = $("<span>").attr("class", "ahzit_headmax").text(response.data.ahzitInfoList[i].ahzitHeadmax + " ");
+						var span_ahzit_sort = $("<span>").attr("class", "span-ahzit-sort").text("#" + response.data.ahzitInfoList[i].ahzitSort);
+						// 3-3)
+						var div_card_text_1 = div_card_text_1_container.append(span_ahzit_head).append(span_ahzit_headmax).append(span_ahzit_sort);
+						
+						var div_card_text_2_container = $("<div>").attr("class", "card-text-2");
+						var i_ahzit_location = $("<i>").attr("class", "fa-solid fa-location-dot");
+						var span_ahzit_location = $("<span>").attr("class", "span-ahzit-location").text(response.data.ahzitInfoList[i].ahzitRegionHigh + " " + response.data.ahzitInfoList[i].ahzitRegionLow);
+						// 3-4) 
+						var div_card_text_2 = div_card_text_2_container.append(i_ahzit_location).append(span_ahzit_location);
+						
+						var div_inner = div_inner_container.append(div_ahzit_img).append(a_ahzit_href).append(div_card_heading).append(div_card_text_1).append(div_card_text_2);
+						
+						var div_outer = div_outer_container.append(div_inner);
+						
+						div_outer.css({
+							position:"relative",
+							top:"50px",
+							opacity:0
+						});
+						div_outer.animate({
+							top:"0px",
+							opacity:1
+						}, 500);
+
+						$(".div-ahzit-list").append(div_outer);
+					}
+				}); 
 			}
-			
-		});
+		}, 100));
+		
 		
 	});
 	

--- a/ahzit/src/main/webapp/WEB-INF/views/ahzit_in/board.jsp
+++ b/ahzit/src/main/webapp/WEB-INF/views/ahzit_in/board.jsp
@@ -1275,6 +1275,8 @@
 			} */
 		})
 		.then(function(response){
+			console.log(response);
+			if(response.data.boardList[0] == null) return;
 			pLast = response.data.plast; // 끝 페이지에 도달하면 비동기 조회를 막기 위해 페이지 끝 번호 설정
 			//console.log(pLast);
 			

--- a/ahzit/src/main/webapp/WEB-INF/views/home.jsp
+++ b/ahzit/src/main/webapp/WEB-INF/views/home.jsp
@@ -147,71 +147,69 @@
 <c:set var="login" value="${loginId != null}"></c:set>
 
 <div class = "container-fulid mt-3">
-	<div class = "row">
 
-		<div class = "col-8 offset-2 ">
-		   <%-- 홈 화면 내용 영역 --%>
-		   <%--이미지 슬라이더 --%>
-			<div class="swiper mb-3">
-                <div class="swiper-wrapper">
-                	<div class="swiper-slide"><img src="images/main-img-1.png" class="main-img"></div>
-                	<div class="swiper-slide"><img src="images/main-img-2.png" class="main-img"></div>
-                	<div class="swiper-slide"><img src="images/main-img-3.png" class="main-img"></div>
-                	<div class="swiper-slide"><img src="images/main-img-4.png" class="main-img"></div>
-                </div>
-                <div class="swiper-pagination"></div>
-                <div class="swiper-button-prev"></div>
-                <div class="swiper-button-next"></div>
-            </div>
-            
-      	<div>
-			<p class="text-center ahzit-title-name">소모임 추천</p> <%--추후 바꾸기 --%>
-		</div>
-            
-            
+	<div class = "col-8 offset-2 ">
+	   <%-- 홈 화면 내용 영역 --%>
+	   <%--이미지 슬라이더 --%>
+		<div class="swiper mb-3">
+               <div class="swiper-wrapper">
+               	<div class="swiper-slide"><img src="images/main-img-1.png" class="main-img"></div>
+               	<div class="swiper-slide"><img src="images/main-img-2.png" class="main-img"></div>
+               	<div class="swiper-slide"><img src="images/main-img-3.png" class="main-img"></div>
+               	<div class="swiper-slide"><img src="images/main-img-4.png" class="main-img"></div>
+               </div>
+               <div class="swiper-pagination"></div>
+               <div class="swiper-button-prev"></div>
+               <div class="swiper-button-next"></div>
+           </div>
+           
+     	<div>
+		<p class="text-center ahzit-title-name">소모임 추천</p> <%--추후 바꾸기 --%>
+	</div>
+           
+           
 
-		<c:if test="${login}">
-		<div>
-			<p class="text-center ahzit-title-name">내가 가입한 소모임</p> 
-		</div>
-		
-		 <div class="row mb-3">
-		<%--card--%>
-		<a href="ahzitUser/myAhzit" class="text-end">가입한 소모임 전부보기<i class="fa-solid fa-angles-right"></i></a>
-		<c:forEach var="myAhzitTopN" items="${myAhzitTopN}">
-		 <div class="mt-4 col-xl-4 col-lg-6 col-md-6 col-sm-6">
-              <div class="card-sl">
-                  <div class="card-image">  <%--아지트 이미지 --%>
-                      <img src = "/attachment/download/ahzit?attachmentNo=${myAhzitTopN.ahzitAttachmentNo}"  onerror=" this.onerror=null; this.src='/images/bg_default.jpg';" class="ahzit-img">
-                  </div>
-                  <a class="card-action" href="${pageContext.request.contextPath}/ahzit_in/${myAhzitTopN.ahzitNo}">
-                  <%--아지트 종류에 따른 아이콘 --%>
-                  <c:if test="${myAhzitTopN.ahzitSort == '취미'}"><img src="/images/hobbies.png"  class="sort-img"></c:if>
-                  <c:if test="${myAhzitTopN.ahzitSort == '스터디'}"><img src="/images/study.png"  class="sort-img"></c:if>
-                  <c:if test="${myAhzitTopN.ahzitSort == '일상'}"><img src="/images/life-smile.png"  class="sort-img"></c:if>
-                  <c:if test="${myAhzitTopN.ahzitSort == '팬클럽'}"><img src="/images/fanclub.png"  class="sort-img"></c:if>
-                  <c:if test="${myAhzitTopN.ahzitSort == '음악'}"><img src="/images/music.png"  class="sort-img"></c:if>
-                  <c:if test="${myAhzitTopN.ahzitSort == '스포츠'}"><img src="/images/sports.png"  class="sort-img"></c:if>
-                  <c:if test="${myAhzitTopN.ahzitSort == '여행'}"><img src="/images/travel.png"  class="sort-img"></c:if>
-                  <c:if test="${myAhzitTopN.ahzitSort == '맛집'}"><img src="/images/eat.png"  class="sort-img"></c:if>
-                  <c:if test="${myAhzitTopN.ahzitSort == '영화'}"><img src="/images/movie.png"  class="sort-img"></c:if>
-                  </a>
-                  <div class="card-heading"> <%--아지트 이름 --%>
-                      ${myAhzitTopN.ahzitName} 
-                  </div>
-                  <div class="card-text-1">  <%--아지트 멤버 수 , 종류 --%>
-                      멤버${myAhzitTopN.ahzitHead} &nbsp;${myAhzitTopN.ahzitSort}
-                  </div>
-                  <div class="card-text-2"> <%--아지트 지역 --%>
-                    <i class="fa-solid fa-location-dot"></i> ${myAhzitTopN.ahzitRegionHigh} ${myAhzitTopN.ahzitRegionLow} 
-                  </div>
-              </div>
+	<c:if test="${login}">
+	<div>
+		<p class="text-center ahzit-title-name">내가 가입한 소모임</p> 
+	</div>
+	
+	 <div class="row mb-3">
+	<%--card--%>
+	<a href="ahzitUser/myAhzit" class="text-end">가입한 소모임 전부보기<i class="fa-solid fa-angles-right"></i></a>
+	<c:forEach var="myAhzitTopN" items="${myAhzitTopN}">
+	 <div class="mt-4 col-xl-4 col-lg-6 col-md-6 col-sm-6">
+             <div class="card-sl">
+                 <div class="card-image">  <%--아지트 이미지 --%>
+                     <img src = "/attachment/download/ahzit?attachmentNo=${myAhzitTopN.ahzitAttachmentNo}"  onerror=" this.onerror=null; this.src='/images/bg_default.jpg';" class="ahzit-img">
+                 </div>
+                 <a class="card-action" href="${pageContext.request.contextPath}/ahzit_in/${myAhzitTopN.ahzitNo}">
+                 <%--아지트 종류에 따른 아이콘 --%>
+                 <c:if test="${myAhzitTopN.ahzitSort == '취미'}"><img src="/images/hobbies.png"  class="sort-img"></c:if>
+                 <c:if test="${myAhzitTopN.ahzitSort == '스터디'}"><img src="/images/study.png"  class="sort-img"></c:if>
+                 <c:if test="${myAhzitTopN.ahzitSort == '일상'}"><img src="/images/life-smile.png"  class="sort-img"></c:if>
+                 <c:if test="${myAhzitTopN.ahzitSort == '팬클럽'}"><img src="/images/fanclub.png"  class="sort-img"></c:if>
+                 <c:if test="${myAhzitTopN.ahzitSort == '음악'}"><img src="/images/music.png"  class="sort-img"></c:if>
+                 <c:if test="${myAhzitTopN.ahzitSort == '스포츠'}"><img src="/images/sports.png"  class="sort-img"></c:if>
+                 <c:if test="${myAhzitTopN.ahzitSort == '여행'}"><img src="/images/travel.png"  class="sort-img"></c:if>
+                 <c:if test="${myAhzitTopN.ahzitSort == '맛집'}"><img src="/images/eat.png"  class="sort-img"></c:if>
+                 <c:if test="${myAhzitTopN.ahzitSort == '영화'}"><img src="/images/movie.png"  class="sort-img"></c:if>
+                 </a>
+                 <div class="card-heading"> <%--아지트 이름 --%>
+                     ${myAhzitTopN.ahzitName} 
+                 </div>
+                 <div class="card-text-1">  <%--아지트 멤버 수 , 종류 --%>
+                     멤버${myAhzitTopN.ahzitHead} &nbsp;${myAhzitTopN.ahzitSort}
+                 </div>
+                 <div class="card-text-2"> <%--아지트 지역 --%>
+                   <i class="fa-solid fa-location-dot"></i> ${myAhzitTopN.ahzitRegionHigh} ${myAhzitTopN.ahzitRegionLow} 
+                 </div>
              </div>
-		 </c:forEach>
-          </div>
-          </c:if>
-		<%--홈 내용영역 끝 --%>
-		</div>
+            </div>
+	 </c:forEach>
+         </div>
+         </c:if>
+	<%--홈 내용영역 끝 --%>
 	</div>
 </div>
 

--- a/ahzit/src/main/webapp/WEB-INF/views/template/footer.jsp
+++ b/ahzit/src/main/webapp/WEB-INF/views/template/footer.jsp
@@ -11,6 +11,9 @@
 	a {
 		color : #9B9BA0;
 	}
+	* {
+		border: 1px dotted gray;
+	}
 </style>
  <footer>
       <!-- Grid container -->
@@ -18,7 +21,6 @@
         <!-- Section: Links -->
         <section>
           <!--Grid row-->
-          <div class="row">
           <div class="col-8 offset-2 d-flex">
             <!-- Grid column -->
             <div class="col-md-3 col-lg-3 col-xl-3 mt-3 mx-auto">
@@ -81,7 +83,7 @@
   
         <!-- Section: Copyright -->
         <section class="pt-0 ">
-          <div class="row d-flex align-items-center">
+          <div class="d-flex align-items-center">
             <!-- Grid column -->
             <div class="col-md-7 col-lg-8 text-center text-md-start col-8 offset-2">
               <!-- Copyright -->
@@ -96,7 +98,6 @@
           </div>
         </section>
         <!-- Section: Copyright -->
-      </div>
       <!-- Grid container -->
     </footer>
     <!-- Footer -->

--- a/ahzit/src/main/webapp/WEB-INF/views/template/header.jsp
+++ b/ahzit/src/main/webapp/WEB-INF/views/template/header.jsp
@@ -46,6 +46,8 @@
   	<!-- 폰트(이사만루체) CDN -->
   	 <link href="https://webfontworld.github.io/gonggames/EsaManru.css" rel="stylesheet">
   	
+  	<!-- AXIOS CDN -->
+	<script src="https://unpkg.com/axios/dist/axios.min.js"></script>
 
   	<!-- Lodash CDN -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js" integrity="sha512-WFN04846sdKMIP5LKNphMaWzU7YpMyCU245etK3g/2ARYbPK9Ub18eG+ljU96qKRCWh+quCY7yefSmlkQw1ANQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>


### PR DESCRIPTION
header.jsp
- 무한 스크롤 구현을 위한 Axios CDN 추가

HomeController
- 무한 스크롤시 마지막 페이지에 도달했을 때 비동기 조회를 방지하기 위해 마지막 페이지블럭을 Model에 추가

ahzit_in/search.jsp
- 소모임 찾기 페이지에서 카테고리별 무한 스크롤 구현

AhzitDao, AhzitDaoImpl
- 찾기 페이지에서 소모임 조회시 메소드 반환형 변경

AhzitRestContoller
- 찾기 페이지에서 각 카테고리별 무한 스크롤 적용을 위한 Mapping 생성
- 무한스크롤 시 소모임 정보를 3개씩 조회하여 반환하도록 변경

AhzitSearchListRequestVO
- 초기 페이지 로드시 6개의 소모임 정보가 보이도록 변경

AhzitSearchRestResponseVO
- 소모임 정보 비동기 조회를 위한 REST 응답 반환 VO 생성

ahzit-mappper.xml
- 소모임 수정 변수명 오류 변경

footer.jsp
- 좌우 스크롤이 생겼던 문제 해결 (row 클래스 삭제)

home.jsp
- 좌우 스크롤이 생겼던 문제 해결 (row 클래스 삭제)